### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/serverinfo:client
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/serverinfo:server
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore